### PR TITLE
fix misleading VAPID email format

### DIFF
--- a/docs/sygnal-setup.md
+++ b/docs/sygnal-setup.md
@@ -128,7 +128,7 @@ apps:
     # This path is *inside the container*. We will map our generated key to it.
     vapid_private_key: /data/private_key.pem
     # An email for VAPID contact details
-    vapid_contact_email: mailto:your-email@your-domain.com
+    vapid_contact_email: your-email@your-domain.com
 ```
 
 #### 3.3. Caddy Configuration (`Caddyfile`)


### PR DESCRIPTION
Sygnal already adds `mailto:` by itself. When added manually, apple will error out with `403: BadJwtToken`. Hence the mailto should be removed